### PR TITLE
Tangle.md: stack init -> stack.yaml; update README and Main.hs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installing
 First make sure to have the tool
 [Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/) installed.
 It comes in some package on most Linux distros, and is available via Homebrew on
-MacOS. Then clone this repository, run `stack init`, followed by `stack build`,
+MacOS. Then clone this repository, run `stack setup`, followed by `stack build`,
 followed by `stack install`. It will copy an executable to `~/.local/bin` (or
 somewhere like that), which you can either copy to somewhere on your `PATH`, or
 symlink to from somewhere in your `PATH`.
@@ -51,8 +51,8 @@ Main Functionality
 The default tangler imports `Pandoc` and the library tangler to implement some
 simple defaults.
 
-Run `stack init`, followed by `stack build` to build the executable. You can run
-`stack install` to place it at `~/.local/bin`.
+Run `stack setup`, followed by `stack build` to build the executable. You can
+run `stack install` to place it at `~/.local/bin`.
 
 See `pandoc-tangle --help` for usage.
 

--- a/Tangle.md
+++ b/Tangle.md
@@ -18,7 +18,7 @@ Installing
 First make sure to have the tool
 [Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/) installed.
 It comes in some package on most Linux distros, and is available via Homebrew on
-MacOS. Then clone this repository, run `stack init`, followed by `stack build`,
+MacOS. Then clone this repository, run `stack setup`, followed by `stack build`,
 followed by `stack install`. It will copy an executable to `~/.local/bin` (or
 somewhere like that), which you can either copy to somewhere on your `PATH`, or
 symlink to from somewhere in your `PATH`.
@@ -51,8 +51,8 @@ Main Functionality
 The default tangler imports `Pandoc` and the library tangler to implement some
 simple defaults.
 
-Run `stack init`, followed by `stack build` to build the executable. You can run
-`stack install` to place it at `~/.local/bin`.
+Run `stack setup`, followed by `stack build` to build the executable. You can
+run `stack install` to place it at `~/.local/bin`.
 
 See `pandoc-tangle --help` for usage.
 

--- a/Tangle.md
+++ b/Tangle.md
@@ -61,6 +61,7 @@ module Main where
 
 import Data.List ( intercalate )
 import Data.List.Split ( splitOn )
+import Data.Monoid ((<>))
 
 import System.IO ( getContents )
 
@@ -68,7 +69,7 @@ import Options.Applicative as OPT ( execParser , Parser , ParserInfo
                                   , strOption , subparser , command , argument
                                   , long , short , metavar , help
                                   , helper , info , fullDesc , progDesc , header
-                                  , many , some , (<>) , str , optional , switch
+                                  , many , some , str , optional , switch
                                   )
 
 import Text.Pandoc         ( Pandoc(Pandoc), Block(CodeBlock, Header, Null, Div)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,8 +13,8 @@
 --- The default tangler imports `Pandoc` and the library tangler to implement some
 --- simple defaults.
 
---- Run `stack init`, followed by `stack build` to build the executable. You can run
---- `stack install` to place it at `~/.local/bin`.
+--- Run `stack setup`, followed by `stack build` to build the executable. You can
+--- run `stack install` to place it at `~/.local/bin`.
 
 --- See `pandoc-tangle --help` for usage.
 


### PR DESCRIPTION
Correctly fixing what https://github.com/ehildenb/pandoc-tangle/pull/4 was intended for. Also, `src/Main.hs` was out of sync with `Tangle.md`, so that's fixed as well. I can do that in a separate PR as well, but that would be kind of messy.