### PR TITLE
added missing handler for CaptionedImage

### DIFF
--- a/tangle.lua
+++ b/tangle.lua
@@ -153,6 +153,10 @@ function Image()
     return ''
 end
 
+function CaptionedImage()
+    return ''
+end
+
 function Note()
     return ''
 end


### PR DESCRIPTION
I had a captioned image in my `.md` file
```
![](resurse/C04/SeussFinal2.JPG)
```
 and was getting a warning:
```
WARNING: Undefined tangle function 'CaptionedImage'
```
Hope this PR is the right way to fix it :-)